### PR TITLE
update the DOAJ connection so that we can retrieve the public data dump

### DIFF
--- a/Importer/jctdata/datasources/doaj.py
+++ b/Importer/jctdata/datasources/doaj.py
@@ -4,7 +4,7 @@ import requests, os
 from jctdata import datasource
 from jctdata import settings
 from datetime import datetime
-
+from jctdata.lib.secrets import get_secret
 
 class DOAJ(datasource.Datasource):
     ID = "doaj"
@@ -33,7 +33,10 @@ class DOAJ(datasource.Datasource):
 
         if not os.path.exists(tarball):
             self.log("downloading latest data dump")
-            resp = requests.get("https://doaj.org/public-data-dump/journal")
+            url = settings.DOAJ_PUBLIC_DATA_DUMP
+            url += "?api_key=" + get_secret(settings.DOAJ_PUBLIC_DATA_DUMP_KEYFILE)
+
+            resp = requests.get(url)
             with open(tarball, "wb") as f:
                 f.write(resp.content)
         self._extract_doaj_data(tarball, out)

--- a/Importer/jctdata/settings.py
+++ b/Importer/jctdata/settings.py
@@ -106,6 +106,10 @@ TJ_SHEET = "https://docs.google.com/spreadsheets/d/e/2PACX-1vT2SPOjVU4CKhP7FHOga
 
 TA_INDEX_SHEET = "https://docs.google.com/spreadsheets/d/e/2PACX-1vStezELi7qnKcyE8OiO2OYx2kqQDOnNsDX1JfAsK487n2uB_Dve5iDTwhUFfJ7eFPDhEjkfhXhqVTGw/pub?gid=1130349201&single=true&output=csv"
 
+DOAJ_PUBLIC_DATA_DUMP = "https://doaj.org/public-data-dump/journal"
+
+DOAJ_PUBLIC_DATA_DUMP_KEYFILE = rel2abs(__file__, "../keyfiles/doaj_public_data_dump.txt")
+
 DOAJ_IN_PROGRESS_URL = "https://doaj.org/jct/inprogress"
 
 DOAJ_IN_PROGRESS_KEYFILE = rel2abs(__file__, "../keyfiles/doaj_inprogress.txt")


### PR DESCRIPTION
This:

* adds the api key to the public data dump request
* puts the details of the public data dump request into the settings file

In order to deploy, the following is required:

1. Add the API key of the JCT DOAJ user into `keyfiles/doaj_public_data_dump.txt` - this can be done easiest by copying the `doaj_inprogress.txt` keyfile
2. Revert the live server settings on the maximum age of the DOAJ datasource to 7 days as before
3. Run all imports that depend on DOAJ (jac and journal):

```
python cli.py load jac journal
```

